### PR TITLE
Added file upload, queue and queueAndReplace to the client

### DIFF
--- a/example.php
+++ b/example.php
@@ -16,14 +16,13 @@ $apiClient = new ApiClient(
     '[ YOUR PASSWORD ]'  // optional
 );
 
-// Or set per request...
+// OR YOU CAN ADJUST USER ACCOUNT DURING A REQUEST
 $apiClient
     ->setUsername('[ YOUR USERNAME ]')
     ->setPassword('[ YOUR PASSWORD ]');
 
 /**
- * GET Example   -------------------------------
- * Showing Exception and error handling options
+ * GET REQUEST EXAMPLE WITH ERROR HANDLING
  */
 try {
     /** @var ApiResponse $response */
@@ -34,19 +33,23 @@ try {
     $response = null;
 }
 
-// Example of error handling
+/**
+ * POSSIBLE ERROR HANDLING APPROACH
+ */
 if (!$response || !$response->isSuccessful()) {
     $errorMessage = $response->getErrorMessage();
     $errorCode = $response->getErrorCode();
 }
 
-// If successful, process the payload
+/**
+ * ON SUCCESS RETRIEVING THE PAYLOAD
+ */
 if ($response->isSuccessful()) {
     $payload = $response->getPayload();
 }
 
 /**
- * POST Example   -------------------------------
+ * POSTING DATA TO THE API
  */
 try {
     /** @var ApiResponse $response */
@@ -58,22 +61,14 @@ try {
         ]
     );
 } catch (ApiException $e) {
-    $response = null;
+    // Handle $e
 }
-
-// If successful, process the payload
-if (!$response) {
-    // do something with $e
-}
-
-// continue processing
 
 /**
- * Log an error to the API   --------------------
+ * SENDING ERROR LOG TO THE API
  */
-
 try {
-    // some code that could fail
+    // some code that throws an exception
 } catch (\Exception $e) {
     // Log the error to the API
     $apiClient->logError(
@@ -81,4 +76,31 @@ try {
         $e->getMessage(),
         ['context' => 'here']
     );
+}
+
+/**
+ * UPLOAD A FILE TO THE API
+ */
+$file = new \SplFileInfo(__DIR__ . DIRECTORY_SEPARATOR . 'sample.pdf');
+
+try {
+    /** @var ApiResponse $response */
+    $response = $apiClient->upload($file);
+    $fileId = $response->getPayload()['id']; // Returns new file ID
+} catch (ApiException $e) {
+    // Handle $e
+}
+
+/**
+ * ADD A FILE TO THE [CLIENT ID]/uploads FOLDER TO BE IMPORTED BY A JOB
+ */
+$file = new \SplFileInfo(__DIR__ . DIRECTORY_SEPARATOR . 'sample.pdf');
+
+try {
+    /** @var ApiResponse $response */
+    $response = $apiClient->queue($file);           // If a FILE ALREADY EXISTS with this name on the server, this will fail.
+    // OR...
+    $response = $apiClient->queueAndReplace($file); // This will REPLACE A FILE of the same name on the server.
+} catch (ApiException $e) {
+    // Handle $e
 }

--- a/sample.pdf
+++ b/sample.pdf
@@ -1,0 +1,198 @@
+%PDF-1.3
+%‚„œ”
+
+1 0 obj
+<<
+/Type /Catalog
+/Outlines 2 0 R
+/Pages 3 0 R
+>>
+endobj
+
+2 0 obj
+<<
+/Type /Outlines
+/Count 0
+>>
+endobj
+
+3 0 obj
+<<
+/Type /Pages
+/Count 2
+/Kids [ 4 0 R 6 0 R ] 
+>>
+endobj
+
+4 0 obj
+<<
+/Type /Page
+/Parent 3 0 R
+/Resources <<
+/Font <<
+/F1 9 0 R 
+>>
+/ProcSet 8 0 R
+>>
+/MediaBox [0 0 612.0000 792.0000]
+/Contents 5 0 R
+>>
+endobj
+
+5 0 obj
+<< /Length 1074 >>
+stream
+2 J
+BT
+0 0 0 rg
+/F1 0027 Tf
+57.3750 722.2800 Td
+( A Simple PDF File ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 688.6080 Td
+( This is a small demonstration .pdf file - ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 664.7040 Td
+( just for use in the Virtual Mechanics tutorials. More text. And more ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 652.7520 Td
+( text. And more text. And more text. And more text. ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 628.8480 Td
+( And more text. And more text. And more text. And more text. And more ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 616.8960 Td
+( text. And more text. Boring, zzzzz. And more text. And more text. And ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 604.9440 Td
+( more text. And more text. And more text. And more text. And more text. ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 592.9920 Td
+( And more text. And more text. ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 569.0880 Td
+( And more text. And more text. And more text. And more text. And more ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 557.1360 Td
+( text. And more text. And more text. Even more. Continued on page 2 ...) Tj
+ET
+endstream
+endobj
+
+6 0 obj
+<<
+/Type /Page
+/Parent 3 0 R
+/Resources <<
+/Font <<
+/F1 9 0 R 
+>>
+/ProcSet 8 0 R
+>>
+/MediaBox [0 0 612.0000 792.0000]
+/Contents 7 0 R
+>>
+endobj
+
+7 0 obj
+<< /Length 676 >>
+stream
+2 J
+BT
+0 0 0 rg
+/F1 0027 Tf
+57.3750 722.2800 Td
+( Simple PDF File 2 ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 688.6080 Td
+( ...continued from page 1. Yet more text. And more text. And more text. ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 676.6560 Td
+( And more text. And more text. And more text. And more text. And more ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 664.7040 Td
+( text. Oh, how boring typing this stuff. But not as boring as watching ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 652.7520 Td
+( paint dry. And more text. And more text. And more text. And more text. ) Tj
+ET
+BT
+/F1 0010 Tf
+69.2500 640.8000 Td
+( Boring.  More, a little more text. The end, and just as well. ) Tj
+ET
+endstream
+endobj
+
+8 0 obj
+[/PDF /Text]
+endobj
+
+9 0 obj
+<<
+/Type /Font
+/Subtype /Type1
+/Name /F1
+/BaseFont /Helvetica
+/Encoding /WinAnsiEncoding
+>>
+endobj
+
+10 0 obj
+<<
+/Creator (Rave \(http://www.nevrona.com/rave\))
+/Producer (Nevrona Designs)
+/CreationDate (D:20060301072826)
+>>
+endobj
+
+xref
+0 11
+0000000000 65535 f
+0000000019 00000 n
+0000000093 00000 n
+0000000147 00000 n
+0000000222 00000 n
+0000000390 00000 n
+0000001522 00000 n
+0000001690 00000 n
+0000002423 00000 n
+0000002456 00000 n
+0000002574 00000 n
+
+trailer
+<<
+/Size 11
+/Root 1 0 R
+/Info 10 0 R
+>>
+
+startxref
+2714
+%%EOF

--- a/tests/unit/Client/ClientTest.php
+++ b/tests/unit/Client/ClientTest.php
@@ -250,4 +250,11 @@ class ClientTest extends ApiClientTestCase
         $this->expectExceptionMessage('Error message is required');
         $this->apiClient->logError(MonologEnum::ERROR, '');
     }
+
+    public function testUploadFailsWithInvalidEndpoint()
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Invalid upload endpoint');
+        $this->apiClient->upload(new \SplFileInfo('path'), '/api/xyz');
+    }
 }


### PR DESCRIPTION
- Added `upload`, `queue` and `queueAndReplace` to the client. This gives us the ability to (multipart) upload files to the API.
- Updated unit tests for `upload` method.