### PR TITLE
Changes to access token request and ApiException handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,6 @@ This repository is currently closed for contribution. Please [report an an issue
 
 ### Tests
 
-There are 35 tests with 97 assertions.
+There are 25 tests with 77 assertions.
 
 Run `./vendor/bin/phpunit tests`

--- a/example.php
+++ b/example.php
@@ -30,6 +30,7 @@ try {
 } catch (ApiException $e) {
     // Handle the exception error (http status code is available)
     $httpStatusCode = $e->getStatusCode();
+    $responseBody = $e->getResponseBody(); // will contain guzzle response body
     $response = null;
 }
 
@@ -39,7 +40,6 @@ try {
 if (!$response || !$response->isSuccessful()) {
     $errorMessage = $response->getErrorMessage();
     $errorCode = $response->getErrorCode();
-    $responseBody = $e->getResponseBody(); // will contain guzzle response body
 }
 
 /**

--- a/example.php
+++ b/example.php
@@ -39,6 +39,7 @@ try {
 if (!$response || !$response->isSuccessful()) {
     $errorMessage = $response->getErrorMessage();
     $errorCode = $response->getErrorCode();
+    $responseBody = $e->getResponseBody(); // will contain guzzle response body
 }
 
 /**

--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -11,8 +11,6 @@ use Hounslow\ApiClient\Enum\HttpStatusCodeEnum;
 use Hounslow\ApiClient\Enum\MonologEnum;
 use Hounslow\ApiClient\Exception\ApiException;
 use Hounslow\ApiClient\Response\ApiResponse;
-use Hounslow\ApiClient\Session\Session;
-use Hounslow\ApiClient\Session\SessionInterface;
 
 class Client
 {
@@ -27,11 +25,6 @@ class Client
      * @var GuzzleClient
      */
     private $guzzleClient;
-
-    /**
-     * @var SessionInterface
-     */
-    private $session;
 
     /**
      * @var string
@@ -64,11 +57,6 @@ class Client
     private $scope = ['*'];
 
     /**
-     * @var AccessToken
-     */
-    private $accessToken;
-
-    /**
      * @param GuzzleClient $guzzleClient
      * @param string $baseUrl
      * @param string $clientId
@@ -85,7 +73,6 @@ class Client
         string $password = ''
     ) {
         $this->setGuzzleClient($guzzleClient);
-        $this->setSession(new Session());
         $this->baseUrl = $baseUrl;
         $this->clientId = $clientId;
         $this->clientSecret = $clientSecret;
@@ -148,14 +135,6 @@ class Client
     }
 
     /**
-     * @param SessionInterface $session
-     */
-    public function setSession(SessionInterface $session)
-    {
-        $this->session = $session;
-    }
-
-    /**
      * @param string $endpoint
      * @param array $data
      * @return ApiResponse
@@ -176,12 +155,14 @@ class Client
                 [
                     RequestOptions::JSON => $data,
                     RequestOptions::HEADERS => [
-                        'Authorization' => 'Bearer ' . $this->getBearerToken(),
+                        'Authorization' => 'Bearer ' . $this->getAccessToken()->getToken(),
                         'Accept' => 'application/json',
                     ],
                     RequestOptions::CONNECT_TIMEOUT => self::CONNECT_TIMEOUT
                 ]
             );
+        } catch (ApiException $e) {
+            throw $e;
         } catch (\Exception $e) {
             throw new ApiException(HttpStatusCodeEnum::INTERNAL_SERVER_ERROR, $e->getMessage());
         }
@@ -208,12 +189,14 @@ class Client
                 $this->baseUrl . $endpoint,
                 [
                     RequestOptions::HEADERS => [
-                        'Authorization' => 'Bearer ' . $this->getBearerToken(),
+                        'Authorization' => 'Bearer ' . $this->getAccessToken()->getToken(),
                         'Accept' => 'application/json',
                     ],
                     RequestOptions::CONNECT_TIMEOUT => self::CONNECT_TIMEOUT
                 ]
             );
+        } catch (ApiException $e) {
+            throw $e;
         } catch (\Exception $e) {
             throw new ApiException(HttpStatusCodeEnum::INTERNAL_SERVER_ERROR, $e->getMessage());
         }
@@ -251,12 +234,14 @@ class Client
                         ]
                     ],
                     RequestOptions::HEADERS => [
-                        'Authorization' => 'Bearer ' . $this->getBearerToken(),
+                        'Authorization' => 'Bearer ' . $this->getAccessToken()->getToken(),
                         'Accept' => 'application/json',
                     ],
                     RequestOptions::CONNECT_TIMEOUT => self::UPLOAD_CONNECT_TIMEOUT
                 ]
             );
+        } catch (ApiException $e) {
+            throw $e;
         } catch (\Exception $e) {
             throw new ApiException(HttpStatusCodeEnum::INTERNAL_SERVER_ERROR, $e->getMessage());
         }
@@ -296,7 +281,7 @@ class Client
      * @throws GuzzleException
      * @throws \Exception
      */
-    public function requestAccessToken()
+    public function getAccessToken()
     {
         if (!$this->getUsername() || !$this->getPassword()) {
             throw new \Exception('Username and Password must be set');
@@ -329,46 +314,27 @@ class Client
             throw new ApiException(HttpStatusCodeEnum::INTERNAL_SERVER_ERROR, 'Unrecognised response from API');
         }
 
-        $accessToken = json_decode((string) $response->getBody(), true);
+        $accessTokenResponse = json_decode((string) $response->getBody(), true);
 
-        if (!$this->isValidAccessTokenArray($accessToken)) {
-            throw new ApiException($response->getStatusCode(), 'Invalid accessToken response');
+        if (!$this->isExpectedAccessTokenResponse($accessTokenResponse)) {
+            throw new ApiException($response->getStatusCode(), 'Unexpected response, access_token not found', json_encode($accessTokenResponse));
         }
 
-        return (new AccessToken())->hydrate($accessToken);
+        return (new AccessToken())
+            ->hydrate($accessTokenResponse);
     }
 
     /**
-     * @param mixed $accessToken
+     * @param mixed $accessTokenResponse
      * @return bool
      */
-    public function isValidAccessTokenArray($accessToken)
+    public function isExpectedAccessTokenResponse($accessTokenResponse)
     {
-        return is_array($accessToken)
-            && isset($accessToken['token_type'])
-            && isset($accessToken['expires_in'])
-            && isset($accessToken['access_token'])
-            && isset($accessToken['refresh_token']);
-    }
-
-    /**
-     * @return string
-     * @throws ApiException
-     * @throws GuzzleException
-     */
-    public function getBearerToken()
-    {
-        $key = md5($this->baseUrl.$this->getUsername().$this->getPassword().$this->clientId);
-        if (
-            !$this->accessToken
-            || !$this->session->has($key)
-            || !$this->session->get($key)->isValid()
-        ) {
-            $accessToken = $this->requestAccessToken();
-            $this->session->set($key, $accessToken);
-            $this->accessToken = $accessToken;
-        }
-        return $this->accessToken->getToken();
+        return is_array($accessTokenResponse)
+            && isset($accessTokenResponse['token_type'])
+            && isset($accessTokenResponse['expires_in'])
+            && isset($accessTokenResponse['access_token'])
+            && isset($accessTokenResponse['refresh_token']);
     }
 
     /**
@@ -401,12 +367,14 @@ class Client
                         'context' => $context
                     ],
                     RequestOptions::HEADERS => [
-                        'Authorization' => 'Bearer ' . $this->getBearerToken(),
+                        'Authorization' => 'Bearer ' . $this->getAccessToken()->getToken(),
                         'Accept' => 'application/json',
                     ],
                     RequestOptions::CONNECT_TIMEOUT => self::CONNECT_TIMEOUT
                 ]
             );
+        } catch (ApiException $e) {
+            throw $e;
         } catch (\Exception $e) {
             throw new ApiException(HttpStatusCodeEnum::INTERNAL_SERVER_ERROR, $e->getMessage());
         }

--- a/src/Exception/ApiException.php
+++ b/src/Exception/ApiException.php
@@ -12,19 +12,27 @@ class ApiException extends \Exception
     private $statusCode;
 
     /**
+     * @var string
+     */
+    private $responseBody;
+
+    /**
      * @param int $statusCode
      * @param string $message
+     * @param string $responseBody
      * @param int $code
      * @param Throwable|null $previous
      */
     public function __construct(
         int $statusCode,
-        string $message = "",
+        string $message = '',
+        string $responseBody = '',
         int $code = 0,
         Throwable $previous = null
     ) {
         parent::__construct($message, $code, $previous);
         $this->statusCode = $statusCode;
+        $this->responseBody = $responseBody;
     }
 
     /**
@@ -33,5 +41,13 @@ class ApiException extends \Exception
     public function getStatusCode()
     {
         return $this->statusCode;
+    }
+
+    /**
+     * @return string
+     */
+    public function getResponseBody()
+    {
+        return $this->responseBody;
     }
 }

--- a/tests/unit/Exception/ApiExceptionTest.php
+++ b/tests/unit/Exception/ApiExceptionTest.php
@@ -10,7 +10,7 @@ class ApiExceptionTest extends ApiClientTestCase
 {
     public function testItSetsStatusCodeCorrectly()
     {
-        $result = new ApiException(HttpStatusCodeEnum::BAD_REQUEST, 'error', 13);
+        $result = new ApiException(HttpStatusCodeEnum::BAD_REQUEST, 'error', '{"unexpected":"response"}', 13);
         $this->assertInstanceOf(\Exception::class, $result);
         $this->assertEquals(HttpStatusCodeEnum::BAD_REQUEST, $result->getStatusCode());
         $this->assertEquals('error', $result->getMessage());


### PR DESCRIPTION
This change is so that we have more visibility over the request to fetch an accessToken and the Guzzle response body of that request.
- The session storage of a valid accessToken has been removed. We cannot go down the route of caching/refreshing the token continuously, so we now request a fresh token each time we make a request.
- In cases where the call to `/api/accessToken` does not return a valid accessToken response (eg. [here](https://github.com/LBHounslow/hounslow-api-client/blob/feature-access-token-updates/src/Client/Client.php#L320)), the Guzzle response body is stored in [ApiException->getResponseBody()](https://github.com/LBHounslow/hounslow-api-client/blob/feature-access-token-updates/src/Exception/ApiException.php#L49) and is available for logging purposes so we can debug issues.

```
PHPUnit 9.5.5 by Sebastian Bergmann and contributors.
.........................                                         25 / 25 (100%)

Time: 00:00.074, Memory: 8.00 MB

OK (25 tests, 77 assertions)
```