### PR TITLE
Prefixed namespace with LBHounslow to avoid conflicts with other packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
   },
   "autoload": {
     "psr-4": {
-      "Hounslow\\ApiClient\\": "src/"
+      "LBHounslow\\ApiClient\\": "src/"
     }
   },
   "autoload-dev": {

--- a/example.php
+++ b/example.php
@@ -2,10 +2,10 @@
 require_once 'vendor/autoload.php';
 
 use GuzzleHttp\Client as GuzzleClient;
-use Hounslow\ApiClient\Client\Client as ApiClient;
-use Hounslow\ApiClient\Enum\MonologEnum;
-use Hounslow\ApiClient\Exception\ApiException;
-use Hounslow\ApiClient\Response\ApiResponse;
+use LBHounslow\ApiClient\Client\Client as ApiClient;
+use LBHounslow\ApiClient\Enum\MonologEnum;
+use LBHounslow\ApiClient\Exception\ApiException;
+use LBHounslow\ApiClient\Response\ApiResponse;
 
 $apiClient = new ApiClient(
     new GuzzleClient(),

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,22 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
-
 <!-- https://phpunit.readthedocs.io/en/latest/configuration.html -->
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         backupGlobals="false"
-         colors="true"
-         bootstrap="vendor/autoload.php"
->
-
+<phpunit bootstrap = "vendor/autoload.php"
+         backupGlobals               = "false"
+         backupStaticAttributes      = "false"
+         colors                      = "true"
+         convertErrorsToExceptions   = "true"
+         convertNoticesToExceptions  = "true"
+         convertWarningsToExceptions = "true"
+         processIsolation            = "false"
+         stopOnFailure               = "false">
     <testsuites>
         <testsuite name="Project Test Suite">
-            <directory>tests/*</directory>
+            <directory>tests</directory>
         </testsuite>
     </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
 </phpunit>

--- a/src/Client/Client.php
+++ b/src/Client/Client.php
@@ -1,16 +1,16 @@
 <?php
 
-namespace Hounslow\ApiClient\Client;
+namespace LBHounslow\ApiClient\Client;
 
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Exception\GuzzleException;
 use GuzzleHttp\Psr7\Response;
 use GuzzleHttp\RequestOptions;
-use Hounslow\ApiClient\Entity\AccessToken;
-use Hounslow\ApiClient\Enum\HttpStatusCodeEnum;
-use Hounslow\ApiClient\Enum\MonologEnum;
-use Hounslow\ApiClient\Exception\ApiException;
-use Hounslow\ApiClient\Response\ApiResponse;
+use LBHounslow\ApiClient\Entity\AccessToken;
+use LBHounslow\ApiClient\Enum\HttpStatusCodeEnum;
+use LBHounslow\ApiClient\Enum\MonologEnum;
+use LBHounslow\ApiClient\Exception\ApiException;
+use LBHounslow\ApiClient\Response\ApiResponse;
 
 class Client
 {

--- a/src/Entity/AccessToken.php
+++ b/src/Entity/AccessToken.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hounslow\ApiClient\Entity;
+namespace LBHounslow\ApiClient\Entity;
 
 class AccessToken
 {

--- a/src/Enum/HttpStatusCodeEnum.php
+++ b/src/Enum/HttpStatusCodeEnum.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hounslow\ApiClient\Enum;
+namespace LBHounslow\ApiClient\Enum;
 
 class HttpStatusCodeEnum
 {

--- a/src/Enum/MonologEnum.php
+++ b/src/Enum/MonologEnum.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hounslow\ApiClient\Enum;
+namespace LBHounslow\ApiClient\Enum;
 
 class MonologEnum
 {

--- a/src/Exception/ApiException.php
+++ b/src/Exception/ApiException.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hounslow\ApiClient\Exception;
+namespace LBHounslow\ApiClient\Exception;
 
 use Throwable;
 

--- a/src/Response/ApiResponse.php
+++ b/src/Response/ApiResponse.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hounslow\ApiClient\Response;
+namespace LBHounslow\ApiClient\Response;
 
 use GuzzleHttp\Psr7\Response;
 

--- a/src/Session/Session.php
+++ b/src/Session/Session.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hounslow\ApiClient\Session;
+namespace LBHounslow\ApiClient\Session;
 
 class Session implements \ArrayAccess, SessionInterface
 {

--- a/src/Session/SessionInterface.php
+++ b/src/Session/SessionInterface.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Hounslow\ApiClient\Session;
+namespace LBHounslow\ApiClient\Session;
 
 interface SessionInterface
 {

--- a/tests/unit/Client/ClientTest.php
+++ b/tests/unit/Client/ClientTest.php
@@ -5,12 +5,12 @@ namespace Tests\Unit\Client;
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Exception\InvalidArgumentException as GuzzleInvalidArgumentException;
 use GuzzleHttp\Psr7\Response as GuzzleResponse;
-use Hounslow\ApiClient\Client\Client as ApiClient;
-use Hounslow\ApiClient\Entity\AccessToken;
-use Hounslow\ApiClient\Enum\HttpStatusCodeEnum;
-use Hounslow\ApiClient\Enum\MonologEnum;
-use Hounslow\ApiClient\Exception\ApiException;
-use Hounslow\ApiClient\Response\ApiResponse;
+use LBHounslow\ApiClient\Client\Client as ApiClient;
+use LBHounslow\ApiClient\Entity\AccessToken;
+use LBHounslow\ApiClient\Enum\HttpStatusCodeEnum;
+use LBHounslow\ApiClient\Enum\MonologEnum;
+use LBHounslow\ApiClient\Exception\ApiException;
+use LBHounslow\ApiClient\Response\ApiResponse;
 use PHPUnit\Framework\MockObject\MockObject;
 use Tests\Unit\ApiClientTestCase;
 

--- a/tests/unit/Entity/AccessTokenTest.php
+++ b/tests/unit/Entity/AccessTokenTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Unit\Entity;
 
-use Hounslow\ApiClient\Entity\AccessToken;
+use LBHounslow\ApiClient\Entity\AccessToken;
 use Tests\Unit\ApiClientTestCase;
 
 class AccessTokenTest extends ApiClientTestCase

--- a/tests/unit/Exception/ApiExceptionTest.php
+++ b/tests/unit/Exception/ApiExceptionTest.php
@@ -2,8 +2,8 @@
 
 namespace Tests\Unit\Exception;
 
-use Hounslow\ApiClient\Enum\HttpStatusCodeEnum;
-use Hounslow\ApiClient\Exception\ApiException;
+use LBHounslow\ApiClient\Enum\HttpStatusCodeEnum;
+use LBHounslow\ApiClient\Exception\ApiException;
 use Tests\Unit\ApiClientTestCase;
 
 class ApiExceptionTest extends ApiClientTestCase

--- a/tests/unit/Response/ApiResponseTest.php
+++ b/tests/unit/Response/ApiResponseTest.php
@@ -3,8 +3,8 @@
 namespace Tests\Unit\Response;
 
 use GuzzleHttp\Psr7\Response as GuzzleResponse;
-use Hounslow\ApiClient\Enum\HttpStatusCodeEnum;
-use Hounslow\ApiClient\Response\ApiResponse;
+use LBHounslow\ApiClient\Enum\HttpStatusCodeEnum;
+use LBHounslow\ApiClient\Response\ApiResponse;
 use Tests\Unit\ApiClientTestCase;
 
 class ApiResponseTest extends ApiClientTestCase


### PR DESCRIPTION
Added LBHounslow prefix to all namespaces to avoid any conflicts with other Bartec packages.

```
hounslow-api-client % ./vendor/bin/phpunit tests                                                                
PHPUnit 9.5.5 by Sebastian Bergmann and contributors.

.........................                                         25 / 25 (100%)

Time: 00:00.029, Memory: 8.00 MB

OK (25 tests, 77 assertions)
```